### PR TITLE
Fixed CS_ERR_MEM returned from cs_open in CodeDisasm::Init

### DIFF
--- a/src/mini_detour.cpp
+++ b/src/mini_detour.cpp
@@ -240,6 +240,15 @@ public:
         _CloseHandle();
 
         cs_err err;
+        cs_opt_mem mem = {
+            (cs_malloc_t)std::malloc,
+            (cs_calloc_t)std::calloc,
+            (cs_realloc_t)std::realloc,
+            (cs_free_t)std::free,
+            (cs_vsnprintf_t)std::vsnprintf
+        };
+
+        cs_option(NULL, CS_OPT_MEM, (size_t) &mem);
         if ((err = cs_open(arch, mode, &_DisasmHandle)) != cs_err::CS_ERR_OK)
             return err;
 

--- a/src/mini_detour.cpp
+++ b/src/mini_detour.cpp
@@ -248,7 +248,7 @@ public:
             (cs_vsnprintf_t)std::vsnprintf
         };
 
-        cs_option(NULL, CS_OPT_MEM, (size_t) &mem);
+        cs_option(NULL, cs_opt_type::CS_OPT_MEM, (size_t) &mem);
         if ((err = cs_open(arch, mode, &_DisasmHandle)) != cs_err::CS_ERR_OK)
             return err;
 


### PR DESCRIPTION
Initialised dynamic memory allocation in capstone dependency through cs_option with default memory management functions in cstdlib